### PR TITLE
Add profile link to project description

### DIFF
--- a/projects/2228cd1289.md
+++ b/projects/2228cd1289.md
@@ -9,7 +9,7 @@ UCL Lead department: [Computer Science](../departments/computer-science.md)
 
 [Department Website](https://www.ucl.ac.uk/computer-science)
 
-Lead Supervisor: Matt Graham
+Lead Supervisor: [Matt Graham](https://profiles.ucl.ac.uk/83112-matt-graham)
 
 Project Summary:
 


### PR DESCRIPTION
Not sure if you are accepting pull requests, but I noticed most other project description pages linked to primary supervisor's UCL Profiles page - this pull request adds such a link to the page for the proposal I submitted.